### PR TITLE
discover service only with name shouldn't require ServiceRequest

### DIFF
--- a/src/main/java/com/totango/discoveryagent/ConsulClient.java
+++ b/src/main/java/com/totango/discoveryagent/ConsulClient.java
@@ -33,7 +33,9 @@ import com.totango.discoveryagent.model.Value;
 
 public class ConsulClient {
   
-  private static final String SERVICE_HEALTH_URL_ENDPOINT = "http://%s:%d/v1/health/service/%s?index=%s&wait=%ds&passing";
+  private static final String SERVICE_HEALTH_URL_ENDPOINT = "http://%s:%d/v1/health/service/%s?passing";
+  
+  private static final String SERVICE_HEALTH_WAIT_URL_ENDPOINT = "http://%s:%d/v1/health/service/%s?index=%s&wait=%ds&passing";
   
   private static final String SERVICE_HEALTH_WITH_TAG_URL_ENDPOINT = "http://%s:%d/v1/health/service/%s?index=%s&tag=%s&wait=%ds&passing";
   
@@ -65,6 +67,11 @@ public class ConsulClient {
     this.waitTimeInSec = waitTimeInSec;
   }
   
+  public Optional<ServiceGroup> discoverService(String serviceName) throws IOException {
+    String url = String.format(SERVICE_HEALTH_URL_ENDPOINT, host, port, serviceName);
+    return getServiceGroup(url);
+  }
+  
   public Optional<ServiceGroup> discoverService(ServiceRequest request) throws IOException {
     String url = buildDiscoverServiceUrl(request);
     return getServiceGroup(url);
@@ -72,7 +79,7 @@ public class ConsulClient {
   
   private String buildDiscoverServiceUrl(ServiceRequest request) {
     if (request.tag() == null) {
-      return String.format(SERVICE_HEALTH_URL_ENDPOINT, host, port, request.serviceName(), request.index(), waitTimeInSec);
+      return String.format(SERVICE_HEALTH_WAIT_URL_ENDPOINT, host, port, request.serviceName(), request.index(), waitTimeInSec);
     }
     
     return String.format(SERVICE_HEALTH_WITH_TAG_URL_ENDPOINT, host, port,

--- a/src/test/java/com/totango/discoveryagent/ConsulClientTest.java
+++ b/src/test/java/com/totango/discoveryagent/ConsulClientTest.java
@@ -56,6 +56,22 @@ public class ConsulClientTest {
 
   private final ServiceRequest serviceRequest = request().forService("whatever").build();
 
+  @Test
+  public void discoverServiceWithServiceNameShouldRetrunTheService() throws Exception {
+    withMockedResponse(new MockResponse().setBody(SERVICE_HEALTH_2_NODES_JSON), (
+        ConsulClient consulClient, MockWebServer server) -> {
+
+      Optional<ServiceGroup> response = consulClient.discoverService(SERVICE1.getServiceName());
+
+      String path = server.takeRequest().getPath();
+      String serviceName = path.substring(path.lastIndexOf('/') + 1, path.indexOf('?'));
+      assertEquals("Service name doesn't match", serviceName, SERVICE1.getServiceName());
+      
+      List<Service> expected = Arrays.asList(SERVICE1, SERVICE2);
+      assertEquals(expected, response.get().getServices());
+    });
+  }
+  
   @Test(expected=IllegalArgumentException.class)
   public void waitTimeoutShouldBeGreaterThan0() {
     ConsulClientFactory consulClientFactory = new ConsulClientFactory();

--- a/src/test/java/com/totango/discoveryagent/DiscoveryServiceTest.java
+++ b/src/test/java/com/totango/discoveryagent/DiscoveryServiceTest.java
@@ -54,7 +54,7 @@ public class DiscoveryServiceTest {
   public void getServiceShouldReturnEmptyServiceListForUnknownService() throws Exception {
     
     ConsulClient consulClient = mock(ConsulClient.class);
-    when(consulClient.discoverService(any())).thenReturn(Optional.empty());
+    when(consulClient.discoverService(any(ServiceRequest.class))).thenReturn(Optional.empty());
     
     DiscoveryService discoveryService = new DiscoveryService(consulClient, 0, i -> i, TimeUnit.MILLISECONDS);
     List<Service> services = discoveryService.getServices("unknown-service");
@@ -68,7 +68,7 @@ public class DiscoveryServiceTest {
     ServiceGroup serviceGroup = new ServiceGroup(expected, Optional.empty());
     
     ConsulClient consulClient = mock(ConsulClient.class);
-    when(consulClient.discoverService(any())).thenReturn(Optional.of(serviceGroup));
+    when(consulClient.discoverService(any(ServiceRequest.class))).thenReturn(Optional.of(serviceGroup));
     
     DiscoveryService discoveryService = new DiscoveryService(consulClient, 0, i -> i, TimeUnit.MILLISECONDS);
     List<Service> services = discoveryService.getServices("pong");
@@ -85,7 +85,7 @@ public class DiscoveryServiceTest {
     ServiceGroup singleServiceGroup = new ServiceGroup(singleService, Optional.empty());
     
     ConsulClient consulClient = mock(ConsulClient.class);
-    when(consulClient.discoverService(any()))
+    when(consulClient.discoverService(any(ServiceRequest.class)))
       .thenReturn(Optional.of(twoServiceGroup));
     
     final List<Service> services = new ArrayList<>();
@@ -107,7 +107,7 @@ public class DiscoveryServiceTest {
       assertEquals(twoServices, services);
     }
 
-    when(consulClient.discoverService(any()))
+    when(consulClient.discoverService(any(ServiceRequest.class)))
       .thenReturn(Optional.of(singleServiceGroup));
     
     await().pollInterval(new Duration(1, MILLISECONDS))


### PR DESCRIPTION
@gilinachum This contains the simple logic to get a service with name (no, tag. index...) without the need to create ServiceRequest
